### PR TITLE
Fix ConcurrentRingBufferWriter wait for commit

### DIFF
--- a/src/Orbit/ConcurrentRingBufferWriter.cs
+++ b/src/Orbit/ConcurrentRingBufferWriter.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 
 namespace Codestellation.Orbit
 {
@@ -43,7 +43,7 @@ namespace Codestellation.Orbit
             var positionToWait = position - count;
             if (positionToWait <= lazyCursorValue)
             {
-                WaitStrategy.WaitFor(positionToWait, Cursor);
+                WaitStrategy.WaitFor(positionToWait + 1, Cursor);
             }
 
             Cursor.VolatileSet(position + 1);


### PR DESCRIPTION
Пусть W1, w2 писатели, и `Cursor=0`

W1 вызывает `Claim` `_nextFree=1`
W2 вызывает `Claim` `_nextFree=2`
W2 вызывает `Commit` с `position=1`, так как `positionToWait=position-1=1-1=0`, а `lazyCursorValue=0`, то W2 начитает ожидать `WaitStrategy.WaitFor(positionToWait, Cursor)`, но ожидания не происходит, так как `positionToWait=Cursor` хотя ожидается, что W2 должен дождаться W1